### PR TITLE
Set STREAMLIT location as in the instructions

### DIFF
--- a/app/setup_script.sql
+++ b/app/setup_script.sql
@@ -110,7 +110,7 @@ GRANT USAGE ON PROCEDURE core.register_single_callback( STRING,  STRING,  STRING
 -- 5. Create a streamlit object using the code you wrote in you wrote in src/module-ui, as shown below.
 -- The `from` value is derived from the stage path described in snowflake.yml
 CREATE OR REPLACE STREAMLIT core.ui
-     FROM '/src/'
+     FROM '/'
      MAIN_FILE = 'ui.py';
 
 -- 6. Grant appropriate privileges over these objects to your application roles.


### PR DESCRIPTION
The instructions tell the user to upload all files to the root of the stage. The setup_script creates STREAMLIT from /src/ subdirectory.

Without this change, application is created but fails to start.

Alternative is to instruct the user to upload the files to a subdirectory but that would involve specifying `src` as the path when uploading files.